### PR TITLE
Fix ingredient list rendering

### DIFF
--- a/_includes/partials/entry.njk
+++ b/_includes/partials/entry.njk
@@ -9,14 +9,12 @@
         {% if entry is string %}
           <li>{{ entry }}</li>
         {% elif entry.items %}
-          </ul>
           {% if entry.section and entry.section != "_main_" %}
-            <p class="text-sm font-semibold text-gray-400 mt-4 mb-2 uppercase tracking-wide">{{ entry.section }}</p>
+            <li class="list-none mt-4 mb-2 text-sm font-semibold text-gray-400 uppercase tracking-wide">{{ entry.section }}</li>
           {% endif %}
-          <ul class="list-disc pl-5 space-y-1">
-            {% for item in entry.items %}
-              <li>{{ item }}</li>
-            {% endfor %}
+          {% for item in entry.items %}
+            <li>{{ item }}</li>
+          {% endfor %}
         {% endif %}
       {% endfor %}
     </ul>


### PR DESCRIPTION
## Summary
- keep ingredient lists in a single `<ul>`
- render ingredient section headers without breaking list markup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892521f20e88321b5934e2b2e9e9bbe